### PR TITLE
Render/load object layers and auto-reload support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3320,8 +3320,7 @@ dependencies = [
 [[package]]
 name = "tiled"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162eb47ee963888a04affec76e698b93e30dd782f983c21be42423ff3aaccefe"
+source = "git+https://github.com/mattyhall/rs-tiled?branch=master#19c311231f1809491583c1e8e45b142d8ca3fa80"
 dependencies = [
  "base64 0.10.1",
  "libflate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,5 @@ anyhow = "1.0"
 bevy = "0.4.0"
 bevy_reflect = "0.4.0"
 glam = "0.11.2"
-tiled = "0.9"
-# tiled = { git = "https://github.com/mattyhall/rs-tiled" }
+#tiled = "0.9"
+tiled = { git = "https://github.com/dmtaub/rs-tiled", branch = "patch-1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ bevy = "0.4.0"
 bevy_reflect = "0.4.0"
 glam = "0.11.2"
 #tiled = "0.9"
-tiled = { git = "https://github.com/dmtaub/rs-tiled", branch = "patch-1" }
+tiled = { git = "https://github.com/mattyhall/rs-tiled", branch = "master" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ impl Plugin for TiledMapPlugin {
     fn build(&self, app: &mut AppBuilder) {
         app.add_asset::<map::Map>()
             .init_asset_loader::<loader::TiledMapLoader>()
+            .add_event::<ObjectReadyEvent>()
             .add_system(process_loaded_tile_maps.system());
 
         let resources = app.resources();

--- a/src/map.rs
+++ b/src/map.rs
@@ -409,6 +409,7 @@ pub struct Object {
     pub shape: tiled::ObjectShape,
     pub position: Vec2,
     pub name: String,
+    visible: bool,
     gid: u32, // sprite ID from tiled::Object
     tileset_gid: Option<u32>, // AKA first_gid
     sprite_index: Option<u32>,
@@ -416,10 +417,11 @@ pub struct Object {
 
 impl Object {
     pub fn new(original_object: &tiled::Object) -> Object {
-        // println!("obj {}", original_object.gid.to_string());
+        // println!("obj {} {}", original_object.name, original_object.visible.to_string());
         Object {
             shape: original_object.shape.clone(),
             gid: original_object.gid, // zero for most non-tile objects
+            visible: original_object.visible,
             tileset_gid: None,
             sprite_index: None,
             position: Vec2::new(original_object.x, original_object.y),
@@ -524,6 +526,11 @@ impl Object {
                     texture_atlas: texture_atlas.clone(),
                     sprite: TextureAtlasSprite {
                         index: sprite_index,
+                        ..Default::default()
+                    },
+                    visible: Visible {
+                        is_visible: self.visible.clone(),
+                        is_transparent: true,
                         ..Default::default()
                     },
                     ..Default::default()

--- a/src/map.rs
+++ b/src/map.rs
@@ -409,7 +409,7 @@ pub struct Object {
     pub shape: tiled::ObjectShape,
     pub position: Vec2,
     pub name: String,
-    visible: bool,
+    pub visible: bool,
     gid: u32, // sprite ID from tiled::Object
     tileset_gid: Option<u32>, // AKA first_gid
     sprite_index: Option<u32>,

--- a/src/map.rs
+++ b/src/map.rs
@@ -13,7 +13,7 @@ use glam::Vec2;
 use std::{io::BufReader, path::Path};
 
 #[derive(Debug)]
-pub struct BevyTile {
+pub struct Tile {
     pub tile_id: u32,
     pub pos: Vec2,
     pub vertex: Vec4,
@@ -21,35 +21,35 @@ pub struct BevyTile {
 }
 
 #[derive(Debug)]
-pub struct BevyChunk {
+pub struct Chunk {
     pub position: Vec2,
-    pub tiles: Vec<Vec<BevyTile>>,
+    pub tiles: Vec<Vec<Tile>>,
 }
 
 #[derive(Debug)]
 pub struct TilesetLayer {
     pub tile_size: Vec2,
-    pub chunks: Vec<Vec<BevyChunk>>,
+    pub chunks: Vec<Vec<Chunk>>,
     pub tileset_guid: u32,
 }
 
 #[derive(Debug)]
-pub struct BevyLayer {
+pub struct Layer {
     pub tileset_layers: Vec<TilesetLayer>,
 }
 
 // An asset for maps
 #[derive(Debug, TypeUuid)]
 #[uuid = "5f6fbac8-3f52-424e-a928-561667fea074"]
-pub struct BevyMap {
+pub struct Map {
     pub map: tiled::Map,
     pub meshes: Vec<(u32, u32, Mesh)>,
-    pub layers: Vec<BevyLayer>,
+    pub layers: Vec<Layer>,
     pub tile_size: Vec2,
     pub image_folder: std::path::PathBuf,
 }
 
-impl BevyMap {
+impl Map {
     pub fn project_ortho(pos: Vec2, tile_width: f32, tile_height: f32) -> Vec2 {
         let x = tile_width * pos.x;
         let y = tile_height * pos.y;
@@ -77,13 +77,13 @@ impl BevyMap {
         let map_center = Vec2::new(self.map.width as f32 / 2.0, self.map.height as f32 / 2.0);
         match self.map.orientation {
             tiled::Orientation::Orthogonal => {
-                let center = BevyMap::project_ortho(map_center, tile_size.x, tile_size.y);
+                let center = Map::project_ortho(map_center, tile_size.x, tile_size.y);
                 Transform::from_matrix(
                     origin.compute_matrix() * Mat4::from_translation(-center.extend(0.0)),
                 )
             }
             tiled::Orientation::Isometric => {
-                let center = BevyMap::project_iso(map_center, tile_size.x, tile_size.y);
+                let center = Map::project_iso(map_center, tile_size.x, tile_size.y);
                 Transform::from_matrix(
                     origin.compute_matrix() * Mat4::from_translation(-center.extend(0.0)),
                 )
@@ -92,7 +92,7 @@ impl BevyMap {
         }
     }
 
-    pub fn try_from_bytes(asset_path: &Path, bytes: Vec<u8>) -> Result<BevyMap> {
+    pub fn try_from_bytes(asset_path: &Path, bytes: Vec<u8>) -> Result<Map> {
         let map = tiled::parse_with_path(BufReader::new(bytes.as_slice()), asset_path).unwrap();
 
         let mut layers = Vec::new();
@@ -168,7 +168,7 @@ impl BevyMap {
                                     // Calculate positions
                                     let (start_x, end_x, start_y, end_y) = match map.orientation {
                                         tiled::Orientation::Orthogonal => {
-                                            let center = BevyMap::project_ortho(
+                                            let center = Map::project_ortho(
                                                 Vec2::new(lookup_x as f32, lookup_y as f32),
                                                 tile_width,
                                                 tile_height,
@@ -187,7 +187,7 @@ impl BevyMap {
                                             (start.x, end.x, start.y, end.y)
                                         }
                                         tiled::Orientation::Isometric => {
-                                            let center = BevyMap::project_iso(
+                                            let center = Map::project_iso(
                                                 Vec2::new(lookup_x as f32, lookup_y as f32),
                                                 tile_width,
                                                 tile_height,
@@ -229,7 +229,7 @@ impl BevyMap {
                                         end_v = temp_startv;
                                     }
 
-                                    BevyTile {
+                                    Tile {
                                         tile_id: map_tile.gid,
                                         pos: Vec2::new(tile_x as f32, tile_y as f32),
                                         vertex: Vec4::new(start_x, start_y, end_x, end_y),
@@ -237,7 +237,7 @@ impl BevyMap {
                                     }
                                 } else {
                                     // Empty tile
-                                    BevyTile {
+                                    Tile {
                                         tile_id: 0,
                                         pos: Vec2::new(tile_x as f32, tile_y as f32),
                                         vertex: Vec4::new(0.0, 0.0, 0.0, 0.0),
@@ -250,7 +250,7 @@ impl BevyMap {
                             tiles.push(tiles_y);
                         }
 
-                        let chunk = BevyChunk {
+                        let chunk = Chunk {
                             position: Vec2::new(chunk_x as f32, chunk_y as f32),
                             tiles,
                         };
@@ -267,7 +267,7 @@ impl BevyMap {
                 tileset_layers.push(tileset_layer);
             }
 
-            let layer = BevyLayer { tileset_layers };
+            let layer = Layer { tileset_layers };
             layers.push(layer);
         }
 
@@ -325,7 +325,7 @@ impl BevyMap {
             }
         }
 
-        let map = BevyMap {
+        let map = Map {
             map,
             meshes,
             layers,
@@ -343,7 +343,7 @@ pub struct TiledMapCenter(pub bool);
 /// A bundle of tiled map entities.
 #[derive(Bundle)]
 pub struct TiledMapComponents {
-    pub map_asset: Handle<BevyMap>,
+    pub map_asset: Handle<Map>,
     pub materials: HashMap<u32, Handle<ColorMaterial>>,
     pub origin: Transform,
     pub center: TiledMapCenter,
@@ -362,7 +362,7 @@ impl Default for TiledMapComponents {
 
 #[derive(Default)]
 pub struct MapResourceProviderState {
-    map_event_reader: EventReader<AssetEvent<BevyMap>>,
+    map_event_reader: EventReader<AssetEvent<Map>>,
 }
 
 #[derive(Bundle)]
@@ -403,19 +403,19 @@ pub fn process_loaded_tile_maps(
     commands: &mut Commands,
     asset_server: Res<AssetServer>,
     mut state: Local<MapResourceProviderState>,
-    map_events: Res<Events<AssetEvent<BevyMap>>>,
-    mut maps: ResMut<Assets<BevyMap>>,
+    map_events: Res<Events<AssetEvent<Map>>>,
+    mut maps: ResMut<Assets<Map>>,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<ColorMaterial>>,
     mut query: Query<(
         Entity,
         &TiledMapCenter,
-        &Handle<BevyMap>,
+        &Handle<Map>,
         &mut HashMap<u32, Handle<ColorMaterial>>,
         &Transform,
     )>,
 ) {
-    let mut changed_maps = HashSet::<Handle<BevyMap>>::default();
+    let mut changed_maps = HashSet::<Handle<Map>>::default();
     for event in state.map_event_reader.iter(&map_events) {
         match event {
             AssetEvent::Created { handle } => {
@@ -432,7 +432,7 @@ pub fn process_loaded_tile_maps(
         }
     }
 
-    let mut new_meshes = HashMap::<&Handle<BevyMap>, Vec<(u32, u32, Handle<Mesh>)>>::default();
+    let mut new_meshes = HashMap::<&Handle<Map>, Vec<(u32, u32, Handle<Mesh>)>>::default();
     for changed_map in changed_maps.iter() {
         let map = maps.get_mut(changed_map).unwrap();
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -623,16 +623,20 @@ pub fn process_loaded_tile_maps(
                         let columns = (texture_width / tile_width).floor() as usize;
                         let rows = (texture_height / tile_height).floor() as usize;
 
-                        let atlas = TextureAtlas::from_grid(
-                            texture_handle.clone(),
-                            Vec2::new(tile_width, tile_height),
-                            columns,
-                            rows
-                        );
-                        let atlas_handle = texture_atlases.add(atlas);
-                        for i in 0..(columns * rows) as u32 {
-                            // println!("insert: {}", tileset.first_gid + i);
-                            texture_atlas_map.insert(tileset.first_gid + i, atlas_handle.clone());
+                        let has_new = (0..(columns*rows) as u32).fold(false, |total, next | total || !texture_atlas_map.contains_key(&(tileset.first_gid + next)));
+                        if has_new {
+                            let atlas = TextureAtlas::from_grid(
+                                texture_handle.clone(),
+                                Vec2::new(tile_width, tile_height),
+                                columns,
+                                rows
+                            );
+                            let atlas_handle = texture_atlases.add(atlas);
+                            for i in 0..(columns * rows) as u32 {
+                                if texture_atlas_map.contains_key(&(tileset.first_gid + i)) { continue; }
+                                // println!("insert: {}", tileset.first_gid + i);
+                                texture_atlas_map.insert(tileset.first_gid + i, atlas_handle.clone());
+                            }
                         }
                     }
                 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -364,11 +364,18 @@ impl Object {
         self.sprite_index = self.tileset_gid.map(|first_gid| &self.gid - first_gid );
     }
     // for now this is here, but it should be in the consuming application
-    pub fn spawn_sprite(&self, commands: &mut Commands, texture_atlas: Option<&Handle<TextureAtlas>> ) {
+    pub fn spawn_sprite(&self,
+        commands: &mut Commands,
+        texture_atlas: Option<&Handle<TextureAtlas>>,
+        map_transform: &Transform,
+    ) {
         match (texture_atlas, self.sprite_index) {
             (Some(texture_atlas), Some(sprite_index)) => {
+                let mut sprite_transform = map_transform.clone();
+                sprite_transform.translation += Vec3::new(self.position.x, self.position.y, 0.01);
+    
                 commands.spawn(SpriteSheetBundle {
-                    // transform: sprite_transform,
+                    transform: sprite_transform,
                     texture_atlas: texture_atlas.clone(),
                     sprite: TextureAtlasSprite {
                         index: sprite_index,
@@ -606,7 +613,7 @@ pub fn process_loaded_tile_maps(
                         tiled::ObjectShape::Rect { width: _, height: _ } => {
                             new_object.set_tile_ids(&tile_gids);
                             new_object.tileset_gid.map(|tileset_gid| {
-                                new_object.spawn_sprite(commands, texture_atlas_map.get(&tileset_gid))
+                                new_object.spawn_sprite(commands, texture_atlas_map.get(&tileset_gid), &tile_map_transform)
                             });
                         }
                         tiled::ObjectShape::Ellipse { width: _ , height: _ } => {}

--- a/src/map.rs
+++ b/src/map.rs
@@ -10,7 +10,7 @@ use bevy_reflect::TypeUuid;
 
 use crate::{loader::TiledMapLoader, TileMapChunk, TILE_MAP_PIPELINE_HANDLE};
 use glam::Vec2;
-use std::{io::BufReader, path::Path};
+use std::{io::BufReader, path::{Path, PathBuf}};
 
 pub use tiled::ObjectShape;
 
@@ -53,6 +53,7 @@ pub struct Map {
     pub groups: Vec<ObjectGroup>,
     pub tile_size: Vec2,
     pub image_folder: std::path::PathBuf,
+    pub asset_dependencies: Vec<PathBuf>,
 }
 
 impl Map {
@@ -132,6 +133,8 @@ impl Map {
         let chunk_size_x = (map.width as f32 / target_chunk_x as f32).ceil().max(1.0) as usize;
         let chunk_size_y = (map.height as f32 / target_chunk_y as f32).ceil().max(1.0) as usize;
         let tile_size = Vec2::new(map.tile_width as f32, map.tile_height as f32);
+        let image_folder: PathBuf = asset_path.parent().unwrap().into();
+        let mut asset_dependencies = Vec::new();
 
         for layer in map.layers.iter() {
             if !layer.visible {
@@ -146,6 +149,9 @@ impl Map {
                 let texture_width = image.width as f32;
                 let texture_height = image.height as f32;
                 let columns = (texture_width / tile_width).floor();
+
+                let tile_path = image_folder.join(tileset.images.first().unwrap().source.as_str());
+                asset_dependencies.push(tile_path);
 
                 let mut chunks = Vec::new();
                 // 32 x 32 tile chunk sizes
@@ -373,7 +379,8 @@ impl Map {
             layers,
             groups,
             tile_size,
-            image_folder: asset_path.parent().unwrap().into(),
+            image_folder,
+            asset_dependencies,
         };
 
         Ok(map)

--- a/src/map.rs
+++ b/src/map.rs
@@ -297,28 +297,19 @@ impl Map {
                             // X + 1, Y
                             positions.push([tile.vertex.z, tile.vertex.y, 0.0]);
 
-                            let mut next_uvs: Vec<(f32, f32)> = Default::default();
+                            let mut next_uvs = [ 
+                                // X, Y
+                                [tile.uv.x, tile.uv.w],
+                                // X, Y + 1
+                                [tile.uv.x, tile.uv.y],
+                                // X + 1, Y + 1
+                                [tile.uv.z, tile.uv.y],
+                                // X + 1, Y
+                                [tile.uv.z, tile.uv.w]
+                            ];
                             if tile.flip_d {
-                                // X + 1, Y + 1
-                                next_uvs.push((tile.uv.z, tile.uv.y));
-                                // X, Y + 1
-                                next_uvs.push((tile.uv.x, tile.uv.y));
-                                // X, Y
-                                next_uvs.push((tile.uv.x, tile.uv.w));
-                                // X + 1, Y
-                                next_uvs.push((tile.uv.z, tile.uv.w));
-                            } else {
-                                // X, Y
-                                next_uvs.push((tile.uv.x, tile.uv.w));
-                                // X, Y + 1
-                                next_uvs.push((tile.uv.x, tile.uv.y));
-                                // X + 1, Y + 1
-                                next_uvs.push((tile.uv.z, tile.uv.y));
-                                // X + 1, Y
-                                next_uvs.push((tile.uv.z, tile.uv.w));
+                                next_uvs.swap(0, 2);
                             }
-
-
                             if tile.flip_h {
                                 next_uvs.reverse();
                             }
@@ -328,7 +319,7 @@ impl Map {
                                 next_uvs.swap(1, 3);
                             }
 
-                            next_uvs.iter().for_each(|uv| uvs.push([uv.0, uv.1]));
+                            next_uvs.iter().for_each(|uv| uvs.push(*uv));
 
                             indices.extend_from_slice(&[i + 0, i + 2, i + 1, i + 0, i + 3, i + 2]);
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -426,6 +426,11 @@ impl Object {
             name: original_object.name.clone()
         }
     }
+
+    pub fn is_shape(&self) -> bool {
+        self.tileset_gid.is_none()
+    }
+
     pub fn new_with_tile_ids(original_object: &tiled::Object, tile_gids: &HashMap<u32, u32>) -> Object {
         // println!("obj {}", original_object.gid.to_string());
         let mut o = Object::new(original_object);

--- a/src/map.rs
+++ b/src/map.rs
@@ -407,6 +407,7 @@ impl ObjectGroup {
 pub struct Object {
     pub shape: tiled::ObjectShape,
     pub position: Vec2,
+    pub name: String,
     gid: u32, // sprite ID from tiled::Object
     tileset_gid: Option<u32>, // AKA first_gid
     sprite_index: Option<u32>,
@@ -421,7 +422,7 @@ impl Object {
             tileset_gid: None,
             sprite_index: None,
             position: Vec2::new(original_object.x, original_object.y),
-//            map_id: Handle<Map>
+            name: original_object.name.clone()
         }
     }
     pub fn create(original_object: &tiled::Object, tile_gids: &HashMap<u32, u32>) -> Object {

--- a/src/map.rs
+++ b/src/map.rs
@@ -12,6 +12,8 @@ use crate::{loader::TiledMapLoader, TileMapChunk, TILE_MAP_PIPELINE_HANDLE};
 use glam::Vec2;
 use std::{io::BufReader, path::Path};
 
+pub use tiled::ObjectShape;
+
 #[derive(Debug)]
 pub struct Tile {
     pub tile_id: u32,
@@ -384,8 +386,8 @@ pub struct TiledMapCenter(pub bool);
 pub struct ObjectGroup {
     name: String,
     opacity: f32,
-    visible: bool,
-    objects: Vec<Object>,
+    pub visible: bool,
+    pub objects: Vec<Object>,
 }
 
 
@@ -403,8 +405,8 @@ impl ObjectGroup {
 
 #[derive(Debug)]
 pub struct Object {
-    shape: tiled::ObjectShape,
-    position: Vec2,
+    pub shape: tiled::ObjectShape,
+    pub position: Vec2,
     gid: u32, // sprite ID from tiled::Object
     tileset_gid: Option<u32>, // AKA first_gid
     sprite_index: Option<u32>,
@@ -522,7 +524,7 @@ impl Default for TiledMapComponents {
 
 #[derive(Default)]
 pub struct MapResourceProviderState {
-    map_event_reader: EventReader<AssetEvent<Map>>,
+    pub map_event_reader: EventReader<AssetEvent<Map>>,
 }
 
 #[derive(Bundle)]

--- a/src/map.rs
+++ b/src/map.rs
@@ -555,6 +555,19 @@ impl Object {
     }
 }
 
+pub struct DebugConfig {
+    pub enabled: bool,
+    pub material: Handle<ColorMaterial>,
+}
+
+impl Default for DebugConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            material: Default::default(),
+        }
+    }
+}
 
 /// A bundle of tiled map entities.
 #[derive(Bundle)]
@@ -564,6 +577,7 @@ pub struct TiledMapComponents {
     pub atlases: HashMap<u32, Handle<TextureAtlas>>,
     pub origin: Transform,
     pub center: TiledMapCenter,
+    pub debug_config: DebugConfig,
 }
 
 impl Default for TiledMapComponents {
@@ -574,6 +588,7 @@ impl Default for TiledMapComponents {
             atlases: HashMap::default(),
             center: TiledMapCenter::default(),
             origin: Transform::default(),
+            debug_config: Default::default(),
         }
     }
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -592,7 +592,7 @@ pub fn process_loaded_tile_maps(
                         );
                         let atlas_handle = texture_atlases.add(atlas);
                         for i in 0..(columns * rows) as u32 {
-                            println!("insert: {}", tileset.first_gid + i);
+                            // println!("insert: {}", tileset.first_gid + i);
                             texture_atlas_map.insert(tileset.first_gid + i, atlas_handle.clone());
                         }
                     }
@@ -661,7 +661,7 @@ pub fn process_loaded_tile_maps(
                 }
                 // TODO: use object_group.name, opacity, colour (properties)
                 for object in object_group.objects.iter() {
-                    println!("in object_group {}, object {}, grp: {}", object_group.name, &object.id, object.gid);
+                    // println!("in object_group {}, object {}, grp: {}", object_group.name, &object.id, object.gid);
                     let mut new_object = Object::new(object);
 
                     match &object.shape {

--- a/src/map.rs
+++ b/src/map.rs
@@ -580,9 +580,9 @@ impl Default for TiledMapComponents {
 
 #[derive(Default)]
 pub struct MapResourceProviderState {
-    pub map_event_reader: EventReader<AssetEvent<Map>>,
-    pub created_layer_entities: HashMap<u32, Vec<Entity>>,
-    pub created_object_entities: HashMap<u32, Vec<Entity>>,
+    map_event_reader: EventReader<AssetEvent<Map>>,
+    created_layer_entities: HashMap<u32, Vec<Entity>>,
+    created_object_entities: HashMap<u32, Vec<Entity>>,
 }
 
 #[derive(Bundle)]
@@ -739,9 +739,11 @@ pub fn process_loaded_tile_maps(
                         })
                         .collect::<Vec<_>>();
 
-                    state.created_layer_entities.get(&tileset_layer.tileset_guid).map(|entities| {
+                    // removing entities consumes the record of created entities
+                    state.created_layer_entities.remove(&tileset_layer.tileset_guid).map(|entities| {
                         // println!("Despawning previously-created mesh for this chunk");
                         for entity in entities.iter() {
+                            // println!("calling despawn on {:?}", entity);
                             commands.despawn(*entity);
                         }
                     });
@@ -770,9 +772,10 @@ pub fn process_loaded_tile_maps(
 
             for object_group in map.groups.iter() {
                 for object in object_group.objects.iter() {
-                    state.created_object_entities.get(&object.gid).map(|entities| {
+                    state.created_object_entities.remove(&object.gid).map(|entities| {
                         // println!("Despawning previously-created object sprite");
                         for entity in entities.iter() {
+                            // println!("calling despawn on {:?}", entity);
                             commands.despawn(*entity);
                         }
                     });

--- a/src/map.rs
+++ b/src/map.rs
@@ -400,19 +400,19 @@ impl Object {
     }
     fn transform(&self, map_transform: &Transform, map_orientation: tiled::Orientation, tile_size: Option<Vec2>) -> Transform{
         let mut transform = map_transform.clone();
-        let object_default_z = 10.0;
-        // transform.translation += Vec3::new(self.position.x, -self.position.y, 0.01);
+        // replacing map Z with something far in front for objects -- should probably be configurable
+        // transform.translation.z = 1000.0;
         match self.shape {
             tiled::ObjectShape::Rect { width, height } => {
                 let scale = tile_size.map(|ts| { Vec2::new(width, height) / ts });
                 match map_orientation {
                     tiled::Orientation::Orthogonal => {
-                        let mut center = Vec2::new(self.position.x + width / 2.0, -self.position.y + height / 2.0).extend(object_default_z);
+                        let mut center = Vec2::new(self.position.x + width / 2.0, -self.position.y + height / 2.0);
                         // apply map scale to object position
-                        center *= transform.scale;
+                        center *= transform.scale.truncate();
                         // replace scale with scale provided by object height/width - allow nonuniform (skew) with max original
                         transform.scale = scale.unwrap_or(Vec2::new(1.0, 1.0)).extend(1.0) * transform.scale.max_element();
-                        transform.translation += center;
+                        transform.translation += center.extend(-center.y / 100.0); // for layering properly, up = farther back
                     }
                     // tiled::Orientation::Isometric => {
                     // }

--- a/src/map.rs
+++ b/src/map.rs
@@ -495,7 +495,7 @@ impl Object {
         texture_atlas: Option<&Handle<TextureAtlas>>,
         map: &tiled::Map,
         tile_map_transform: &Transform,
-        debug_material: Handle<ColorMaterial>,
+        debug_config: &DebugConfig,
     ) -> &'a mut Commands {
         if let Some(texture_atlas) = texture_atlas {
             let sprite_index = self.sprite_index.expect("missing sprite index");
@@ -531,10 +531,11 @@ impl Object {
             commands
                 // Debug box.
                 .spawn(SpriteBundle {
-                    material: debug_material,
+                    material: debug_config.material.clone().unwrap_or_else(|| Handle::<ColorMaterial>::default()),
                     sprite: Sprite::new(dimensions),
                     transform,
                     visible: Visible {
+                        is_visible: debug_config.enabled,
                         is_transparent: true,
                         ..Default::default()
                     },
@@ -651,7 +652,7 @@ pub fn process_loaded_tile_maps(
         &mut HashMap<u32, Handle<ColorMaterial>>,
         &mut HashMap<u32, Handle<TextureAtlas>>,
         &Transform,
-        &DebugConfig,
+        &mut DebugConfig,
     )>,
 ) {
     let mut changed_maps = HashSet::<Handle<Map>>::default();
@@ -731,7 +732,7 @@ pub fn process_loaded_tile_maps(
         }
     }
 
-    for (_, center, map_handle, materials_map, texture_atlas_map, origin, debug_config) in query.iter_mut() {
+    for (_, center, map_handle, materials_map, texture_atlas_map, origin, mut debug_config) in query.iter_mut() {
         if new_meshes.contains_key(map_handle) {
             let map = maps.get(map_handle).unwrap();
 
@@ -786,7 +787,9 @@ pub fn process_loaded_tile_maps(
                 }
             }
 
-            let debug_material = debug_config.material.clone().unwrap_or_else(|| materials.add(ColorMaterial::from(Color::rgba(0.4, 0.4, 0.9, 0.5))));
+            if debug_config.enabled && debug_config.material.is_none() {
+                debug_config.material = Some(materials.add(ColorMaterial::from(Color::rgba(0.4, 0.4, 0.9, 0.5))));
+            }
             for object_group in map.groups.iter() {
                 for object in object_group.objects.iter() {
                     state.created_object_entities.remove(&object.gid).map(|entities| {
@@ -812,7 +815,7 @@ pub fn process_loaded_tile_maps(
                             atlas_handle,
                             &map.map,
                             &tile_map_transform,
-                            debug_material.clone(),
+                            &debug_config,
                         )
                         .current_entity().map(|entity| {
                             // when done spawning, fire event

--- a/src/map.rs
+++ b/src/map.rs
@@ -508,6 +508,7 @@ impl Object {
         commands: &'a mut Commands,
         texture_atlas: Option<&Handle<TextureAtlas>>,
         map: &tiled::Map,
+        map_handle: Handle<Map>,
         tile_map_transform: &Transform,
         debug_config: &DebugConfig,
     ) -> &'a mut Commands {
@@ -541,7 +542,6 @@ impl Object {
                     },
                     ..Default::default()
                 })
-                .with(self.clone())
         } else {
             // commands.spawn((self.map_transform(&map.map, &tile_map_transform, None), GlobalTransform::default()))
             let dimensions = self.dimensions().expect("Don't know how to handle object without dimensions");
@@ -559,8 +559,9 @@ impl Object {
                     },
                     ..Default::default()
                 })
-                .with(self.clone())
         }
+        .with(map_handle)
+        .with(self.clone())
     }
 
     pub fn dimensions(&self) -> Option<Vec2> {
@@ -629,6 +630,7 @@ pub struct CreatedMapEntities {
 
 #[derive(Bundle)]
 pub struct ChunkComponents {
+    pub map_parent: Handle<Map>, // tmp:chunks should be child entities of a toplevel map entity.
     pub chunk: TileMapChunk,
     pub main_pass: MainPass,
     pub material: Handle<ColorMaterial>,
@@ -643,6 +645,7 @@ pub struct ChunkComponents {
 impl Default for ChunkComponents {
     fn default() -> Self {
         Self {
+            map_parent: Handle::default(),
             chunk: TileMapChunk::default(),
             visible: Visible {
                 is_transparent: true,
@@ -806,6 +809,7 @@ pub fn process_loaded_tile_maps(
                             },
                             material: material_handle.clone(),
                             mesh: mesh.clone(),
+                            map_parent: map_handle.clone(),
                             transform: tile_map_transform.clone(),
                             ..Default::default()
                         }).current_entity().map(|new_entity| {
@@ -844,6 +848,7 @@ pub fn process_loaded_tile_maps(
                             commands,
                             atlas_handle,
                             &map.map,
+                            map_handle.clone(),
                             &tile_map_transform,
                             &debug_config,
                         )

--- a/src/map.rs
+++ b/src/map.rs
@@ -609,7 +609,7 @@ impl Default for TiledMapComponents {
 #[derive(Default)]
 pub struct MapResourceProviderState {
     map_event_reader: EventReader<AssetEvent<Map>>,
-    created_layer_entities: HashMap<u32, Vec<Entity>>,
+    created_layer_entities: HashMap<(usize, u32), Vec<Entity>>, // maps layer id and tileset_gid to mesh entities
     created_object_entities: HashMap<u32, Vec<Entity>>,
 }
 
@@ -769,7 +769,7 @@ pub fn process_loaded_tile_maps(
                         .collect::<Vec<_>>();
 
                     // removing entities consumes the record of created entities
-                    state.created_layer_entities.remove(&tileset_layer.tileset_guid).map(|entities| {
+                    state.created_layer_entities.remove(&(layer_id, tileset_layer.tileset_guid)).map(|entities| {
                         // println!("Despawning previously-created mesh for this chunk");
                         for entity in entities.iter() {
                             // println!("calling despawn on {:?}", entity);
@@ -792,7 +792,7 @@ pub fn process_loaded_tile_maps(
                             ..Default::default()
                         }).current_entity().map(|new_entity| {
                             // println!("added created_entry after spawn");
-                            state.created_layer_entities.entry(*tileset_guid)
+                            state.created_layer_entities.entry((layer_id, *tileset_guid))
                                 .or_insert_with(|| Vec::new()).push(new_entity);
                         });
                     }


### PR DESCRIPTION
This adds basic support for rectangular objects (including tile sprite objectes!) in Orthographic mode. We also add auto-reload support via asset events. 

**Note: this branch includes my other PR changes (tile rotation fix) as well as @framp's bevy 0.4.0 changes**

Objects without tile maps also may be made visible by way of passing the debug configuration object to the TiledMapComponents bundle:
```
debug_config: DebugConfig {
    enabled: true,
    ..Default::default()
},
```
When an object is created, it fires an ObjectReadyEvent event which includes the map asset handle and the entity ID for the newly-created object. This allows additional custom behavior in consuming application (e.g. collision).

I haven't done any testing/implementation of isometric, as I haven't been working with isometric maps in my project :)  

There isn't yet any support for round or polygon objects, but I wanted to do that next. Because it's hard to visualize and I like the bevy_tiled having the responsibility for spawning entities, I was going to add [lyon](https://github.com/Nilirad/bevy_prototype_lyon) as a dependency to allow debug visualizations of circle/polygon cases. However, I recognize how it might not make sense to open PRs after adding a new dependency, so I wanted to issue this PR first...

OTOH, if you like this direction, I will write up some documentation. and maybe find time to look at isometric objects.